### PR TITLE
Fix Checklist Mapping References and Update File Extensions

### DIFF
--- a/bmad-agent/tasks/checklist-mappings.yml
+++ b/bmad-agent/tasks/checklist-mappings.yml
@@ -1,12 +1,12 @@
 architect-checklist:
-  checklist_file: docs/checklists/architect-checklist.txt
+  checklist_file: docs/checklists/architect-checklist.md
   required_docs:
     - architecture.md
   default_locations:
     - docs/architecture.md
 
 frontend-architecture-checklist:
-  checklist_file: docs/checklists/frontend-architecture-checklist.txt
+  checklist_file: docs/checklists/frontend-architecture-checklist.md
   required_docs:
     - frontend-architecture.md
   default_locations:
@@ -14,14 +14,14 @@ frontend-architecture-checklist:
     - docs/fe-architecture.md
 
 pm-checklist:
-  checklist_file: docs/checklists/pm-checklist.txt
+  checklist_file: docs/checklists/pm-checklist.md
   required_docs:
     - prd.md
   default_locations:
     - docs/prd.md
 
 po-master-checklist:
-  checklist_file: docs/checklists/po-master-checklist.txt
+  checklist_file: docs/checklists/po-master-checklist.md
   required_docs:
     - prd.md
     - architecture.md
@@ -33,14 +33,14 @@ po-master-checklist:
     - docs/architecture.md
 
 story-draft-checklist:
-  checklist_file: docs/checklists/story-draft-checklist.txt
+  checklist_file: docs/checklists/story-draft-checklist.md
   required_docs:
     - story.md
   default_locations:
     - docs/stories/*.md
 
 story-dod-checklist:
-  checklist_file: docs/checklists/story-dod-checklist.txt
+  checklist_file: docs/checklists/story-dod-checklist.md
   required_docs:
     - story.md
   default_locations:


### PR DESCRIPTION
I have made the following changes to improve the checklist mapping and ensure that the references are accurate:

**Updated File Extensions:**

1. Changed the file extensions in the checklist references from .txt to .md to reflect the conversion of documents to Markdown format.

2. Corrected the references in the checklist mapping YAML file to ensure they point to the correct Markdown files.

These changes ensure that the checklist mappings are accurate and consistent with the current file formats, which should help avoid any confusion or errors when accessing the referenced documents.