### PR TITLE
Javascript `build-web-agent.js` fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ build/
 
 # Environment variables
 .env
+
+# VSCode settings
+.vscode/

--- a/build-web-agent.js
+++ b/build-web-agent.js
@@ -60,7 +60,6 @@ async function main() {
   }
 
   // 2. Determine and validate asset folder root and build directory
-  const _workspaceRoot = path.resolve(__dirname, ".");
 
   const assetFolderRootInput = config.asset_root;
   let assetFolderRoot;

--- a/build-web-agent.js
+++ b/build-web-agent.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
 
 // --- Configuration ---
 const configFilePath = "./build-web-agent.cfg.js"; // Path relative to this script (__dirname)
@@ -60,7 +60,7 @@ async function main() {
   }
 
   // 2. Determine and validate asset folder root and build directory
-  const workspaceRoot = path.resolve(__dirname, ".");
+  const _workspaceRoot = path.resolve(__dirname, ".");
 
   const assetFolderRootInput = config.asset_root;
   let assetFolderRoot;
@@ -193,7 +193,7 @@ Discovering source directories in '${assetFolderRoot}' (excluding '${buildDirNam
               `       Conflicting files: '${baseFilenamesSeen[baseName]}' and '${filenameWithExt}'.`
             );
             console.error(
-              `       Please ensure all files in a subdirectory have unique names after removing their last extensions.`
+              "       Please ensure all files in a subdirectory have unique names after removing their last extensions."
             );
             process.exit(1);
           } else {


### PR DESCRIPTION
# Javascript `build-web-agent.js` fixes

## Summary

This PR updates the `build-web-agent.js` script to use Node.js built-in module prefixes and removes an unused variable. Additionally, it adds VSCode settings directory to .gitignore and fixes a string interpolation issue in an error message.

## Files Changed

### `.gitignore`
Added `.vscode/` directory to the ignore list to prevent VSCode-specific settings from being committed to the repository.

### `build-web-agent.js`
- Updated module imports to use Node.js built-in module prefixes (`node:fs` and `node:path`)
- Removed unused `workspaceRoot` variable
- Fixed string interpolation in error message to use a plain string

## Code Changes

### `.gitignore`
```diff
+# VSCode settings
+.vscode/
```

### `build-web-agent.js`

1. **Module imports updated to use Node.js prefixes:**
```diff
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
```

2. **Removed unused variable:**
```diff
-  const workspaceRoot = path.resolve(__dirname, ".");
```

3. **Fixed string interpolation in error message:**
```diff
-              `       Please ensure all files in a subdirectory have unique names after removing their last extensions.`
+              "       Please ensure all files in a subdirectory have unique names after removing their last extensions."
```

## Reason for Changes

1. **Node.js module prefixes**: Using the `node:` prefix for built-in modules is a modern best practice that clearly distinguishes between built-in Node.js modules and third-party packages. This helps prevent potential conflicts with npm packages that might have the same name.

2. **Unused variable removal**: The `workspaceRoot` variable was declared but never used in the code, contributing to unnecessary code clutter.

3. **String interpolation fix**: The error message was using template literal syntax (backticks) without any actual interpolation, so it's been converted to a regular string for clarity.

4. **VSCode settings exclusion**: Adding `.vscode/` to gitignore ensures that developer-specific VSCode configurations don't get committed to the repository, maintaining a clean codebase.

## Impact of Changes

- **No functional changes**: These updates are purely cosmetic and don't affect the runtime behavior of the build script
- **Improved code clarity**: Using Node.js module prefixes makes dependencies more explicit
- **Cleaner codebase**: Removing unused variables and fixing unnecessary template literals improves code maintainability
- **Better developer experience**: Ignoring VSCode settings prevents conflicts between different developers' IDE configurations

## Screenshots

Before fix:

![image](https://github.com/user-attachments/assets/fbc0af5c-8ed5-409a-925a-a4b57a59d424)

After fix:

![image](https://github.com/user-attachments/assets/c303082e-7f3f-421a-b21a-f05de05857c5)

## Test Plan

Since these changes are non-functional:
1. Run the build script to ensure it executes without errors
2. Verify that the script still correctly processes asset files as before
3. Confirm that `.vscode/` directory (if present) is properly ignored by git

## Additional Notes

These changes follow Node.js best practices and help maintain a cleaner, more maintainable codebase. The use of `node:` prefixes is particularly recommended in newer Node.js versions (14.18.0+, 16.0.0+) to avoid ambiguity between built-in and external modules.
