### PR TITLE
docs: update README links to renamed orchestrator config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here are the more [Setup and Usage Instructions](./docs/instruction.md) for IDE,
 
 Starting with the latest version of the BMad Agents for the BMad Method is very easy - all you need to do is copy `bmad-agent` folder to your project. The dedicated dev and sm that existing in previous versions are still available and are in the `bmad-agent/personas` folder with the .ide.md extension. Copy and paste the contents into your specific IDE's method of configuring a custom agent mode. The dev and sm both are configured for architecture and prd artifacts to be in (project-root)/docs and stories will be generated and developed in/from your (project-root)/docs/stories.
 
-For all other agent use (including the dev and sm) you can set up the [ide orchestrator](bmad-agent/bmad-agent.ide.md) - you can ask the orchestrator bmad to become any agent you have [configured](bmad-agent/bmad-orchestrator.ide.cfg.md).
+For all other agent use (including the dev and sm) you can set up the [ide orchestrator](bmad-agent/ide-bmad-orchestrator.md) - you can ask the orchestrator bmad to become any agent you have [configured](bmad-agent/ide-bmad-orchestrator.cfg.md).
 
 [General IDE Custom Mode Setup](./docs/ide-setup.md).
 

--- a/bmad-agent/ide-bmad-orchestrator.md
+++ b/bmad-agent/ide-bmad-orchestrator.md
@@ -5,14 +5,14 @@
 
 ## Core Orchestrator Principles
 
-1.  **Config-Driven Authority:** All knowledge of available personas, tasks, persona files, task files, and global resource paths (for templates, checklists, data) MUST originate from the loaded Config.
-2.  **Global Resource Path Resolution:** When an active persona executes a task, and that task file (or any other loaded content) references templates, checklists, or data files by filename only, their full paths MUST be resolved using the appropriate base paths defined in the `Data Resolution` section of the Config - assume extension is md if not specified.
-3.  **Single Active Persona Mandate:** Embody ONLY ONE specialist persona at a time.
-4.  **Clarity in Operation:** Always be clear about which persona is currently active and what task is being performed.
+1. **Config-Driven Authority:** All knowledge of available personas, tasks, persona files, task files, and global resource paths (for templates, checklists, data) MUST originate from the loaded Config.
+2. **Global Resource Path Resolution:** When an active persona executes a task, and that task file (or any other loaded content) references templates, checklists, or data files by filename only, their full paths MUST be resolved using the appropriate base paths defined in the `Data Resolution` section of the Config - assume extension is md if not specified.
+3. **Single Active Persona Mandate:** Embody ONLY ONE specialist persona at a time.
+4. **Clarity in Operation:** Always be clear about which persona is currently active and what task is being performed.
 
 ## Critical Start-Up & Operational Workflow
 
-### 1. Initialization & User Interaction Prompt:
+### 1. Initialization & User Interaction Prompt
 
 - CRITICAL: Your FIRST action: Load & parse `configFile` (hereafter "Config"). This Config defines ALL available personas, their associated tasks, and resource paths. If Config is missing or unparsable, inform user that you cannot locate the config and can only operate as a BMad Method Advisor (based on the kb data).
   Greet the user concisely (e.g., "BMad IDE Orchestrator ready. Config loaded. Select Agent, or I can remain in Advisor mode.").
@@ -20,7 +20,7 @@
   - Based on the loaded Config, list available specialist personas by their `Title` (and `Name` if distinct) along with their `Description`. For each persona, list the display names of its configured `Tasks`.
   - Ask: "Which persona shall I become, and what task should it perform?" Await user's specific choice.
 
-### 2. Persona Activation & Task Execution:
+### 2. Persona Activation & Task Execution
 
 - **A. Activate Persona:**
   - From the user's request, identify the target persona by matching against `Title` or `Name` in the Config.
@@ -39,7 +39,7 @@
     - **If an "In Memory" task:** Follow as stated internally.
   - Upon task completion continue interacting as the active persona.
 
-### 3. Handling Requests for Persona Change (While a Persona is Active):
+### 3. Handling Requests for Persona Change (While a Persona is Active)
 
 - If you are currently embodying a specialist persona and the user requests to become a _different_ persona, suggest starting new chat, but let them choose to `Proceed (y/n)?`
 - **If user chooses to override:**


### PR DESCRIPTION
# docs: update README links to renamed orchestrator config files

## Summary

This PR updates broken links in the README.md file and improves the formatting consistency in the BMad IDE Orchestrator documentation. The changes ensure that users can properly access the orchestrator configuration files and enhance the readability of the orchestrator documentation.

Fixes #112 

## Files Changed

- **README.md**: Fixed broken links to the BMad IDE orchestrator documentation files
- **bmad-agent/ide-bmad-orchestrator.md**: Improved formatting consistency in section headers

## Code Changes

### README.md
```diff
-For all other agent use (including the dev and sm) you can set up the [ide orchestrator](bmad-agent/bmad-agent.ide.md) - you can ask the orchestrator bmad to become any agent you have [configured](bmad-agent/bmad-orchestrator.ide.cfg.md).
+For all other agent use (including the dev and sm) you can set up the [ide orchestrator](bmad-agent/ide-bmad-orchestrator.md) - you can ask the orchestrator bmad to become any agent you have [configured](bmad-agent/ide-bmad-orchestrator.cfg.md).
```

The links were pointing to non-existent files with incorrect naming conventions. Updated to match the actual file names in the repository.

### bmad-agent/ide-bmad-orchestrator.md
```diff
-### 1. Initialization & User Interaction Prompt:
+### 1. Initialization & User Interaction Prompt

-### 2. Persona Activation & Task Execution:
+### 2. Persona Activation & Task Execution

-### 3. Handling Requests for Persona Change (While a Persona is Active):
+### 3. Handling Requests for Persona Change (While a Persona is Active)
```

Removed trailing colons from section headers and adjusted the numbered list formatting to maintain consistency throughout the document.

## Reason for Changes

1. **Broken Links**: The README contained links to files that didn't exist with the specified names, which would result in 404 errors for users trying to access the orchestrator documentation
2. **Formatting Consistency**: The orchestrator documentation had inconsistent formatting in its section headers, with some using colons and others not

## Impact of Changes

- **User Experience**: Users will now be able to successfully navigate to the BMad orchestrator documentation from the README
- **Documentation Quality**: The orchestrator documentation now has consistent formatting, making it easier to read and maintain
- **No Functional Changes**: These are purely documentation updates with no impact on code functionality

## Test Plan

- Verified that the updated links in README.md point to existing files
- Confirmed that the markdown formatting renders correctly in preview
- Checked that no other references to these files exist that would need updating

## Additional Notes

The file naming convention appears to follow a pattern of `ide-bmad-[component].md` rather than the previous `bmad-[component].ide.md` pattern. This PR aligns the README links with the actual file structure.
