### PR TITLE
fix: update documentation and installer to reflect .roomodes file location in project root

### DIFF
--- a/docs/roo-code-guide.md
+++ b/docs/roo-code-guide.md
@@ -13,7 +13,7 @@ This guide walks you through the complete BMAD workflow using Roo Code as your A
    - **Installation Type**: Choose "Complete installation (recommended)"
    - **IDE**: Select "Roo Code"
 
-This creates a `.bmad-core` folder with all agents and a `.roo/.roomodes` file with custom modes.
+This creates a `.bmad-core` folder with all agents and a `.roomodes` file (in the project root) with custom modes.
 
 ## Step 2: Set Up Team Fullstack in Gemini
 
@@ -103,7 +103,7 @@ All BMAD agents are available as custom modes:
 
 ## Roo Code-Specific Features
 
-- **Custom modes are stored in**: `.roo/.roomodes` file
+- **Custom modes are stored in**: `.roomodes` file (in the project root)
 - **Mode switching**: Use the mode selector in Roo Code's interface
 - **File permissions**: Each agent has specific file access permissions
   - **Documentation agents** (SM, PM, PO, Analyst): Limited to `.md` and `.txt` files

--- a/tools/installer/lib/ide-setup.js
+++ b/tools/installer/lib/ide-setup.js
@@ -241,8 +241,8 @@ class IdeSetup {
     const rooDir = path.join(installDir, ".roo");
     await fileManager.ensureDirectory(rooDir);
 
-    // Check for existing .roomodes file inside .roo directory
-    const roomodesPath = path.join(rooDir, ".roomodes");
+    // Check for existing .roomodes file in project root
+    const roomodesPath = path.join(installDir, ".roomodes");
     let existingModes = [];
     let existingContent = "";
 
@@ -349,7 +349,7 @@ class IdeSetup {
           newModesContent += `   customInstructions: CRITICAL Read the full YML from .bmad-core/agents/${agentId}.md start activation to alter your state of being follow startup section instructions stay in this being until told to exit this mode\n`;
           newModesContent += `   groups:\n`;
           newModesContent += `    - read\n`;
-          
+
           // Add permissions based on agent type
           const permissions = agentPermissions[agentId];
           if (permissions) {
@@ -379,7 +379,7 @@ class IdeSetup {
 
     // Write .roomodes file
     await fileManager.writeFile(roomodesPath, roomodesContent);
-    console.log(chalk.green("✓ Created .roo/.roomodes file"));
+    console.log(chalk.green("✓ Created .roomodes file in project root"));
 
     // Create README in .roo directory
     const rooReadme = `# Roo Code Custom Modes for BMAD-METHOD


### PR DESCRIPTION
Fix: Corrects Roo Code mode file location and updates docs

This PR addresses an issue where the BMAD installer placed the `.roomodes` file in the `.roo/` subdirectory, while Roo Code expects project-specific mode files to be in the project root.

**Changes:**

1.  **Installer Update (`tools/installer/lib/ide-setup.js`):**
    *   Modified the `setupRoo` function to create the `.roomodes` file directly in the project's root directory instead of `.roo/.roomodes`.
2.  **Documentation Update (`docs/roo-code-guide.md`):**
    *   Updated the guide to reflect that the installer now places the `.roomodes` file in the project root.

These changes ensure that Roo Code can correctly discover and load the BMAD custom modes as intended.

Fixes #235