### PR TITLE
Fixes a potential build issue on Windows.

### DIFF
--- a/tools/lib/dependency-resolver.js
+++ b/tools/lib/dependency-resolver.js
@@ -15,7 +15,7 @@ class DependencyResolver {
     const agentContent = await fs.readFile(agentPath, 'utf8');
     
     // Extract YAML from markdown content
-    const yamlMatch = agentContent.match(/```ya?ml\n([\s\S]*?)\n```/);
+    const yamlMatch = agentContent.replace(/\r/g, "").match(/```ya?ml\n([\s\S]*?)\n```/);
     if (!yamlMatch) {
       throw new Error(`No YAML configuration found in agent ${agentId}`);
     }


### PR DESCRIPTION
When cloning a project in a Windows environment, Git may automatically convert line endings from `\n` to `\r\n`. This can cause a mismatch in the `yaml` configuration, leading to a build failure. To resolve this, a step has been added to enforce the replacement of `\r` characters, ensuring the build can proceed normally.