### PR TITLE
fix: support Windows-style newlines in YAML block regex

### DIFF
--- a/tools/installer/lib/ide-setup.js
+++ b/tools/installer/lib/ide-setup.js
@@ -702,7 +702,7 @@ class IdeSetup {
         const agentContent = await fileManager.readFile(agentPath);
 
         // Extract YAML content
-        const yamlMatch = agentContent.match(/```ya?ml\n([\s\S]*?)```/);
+        const yamlMatch = agentContent.match(/```ya?ml\r?\n([\s\S]*?)```/);
         if (yamlMatch) {
           const yaml = yamlMatch[1];
 


### PR DESCRIPTION
## What

Updated the regular expression used to extract agentContent in setupRoo function to support both Unix (`\n`) and Windows (`\r\n`) newline styles.

## Why

When using the installer on Windows  it generates an empty .roomodes file which means it couldn't get the content correctly , `agentContent.match()` was returning `null` due to the regex expecting only Unix-style newlines (`\n`). Since Windows encodes line endings as `\r\n`, YAML blocks enclosed in triple backticks were not detected, breaking parsing functionality on Windows environments.

Fixes #310

## How

- Updated the regex pattern from `/```ya?ml\n([\s\S]*?)```/` to `/```ya?ml\r?\n([\s\S]*?)```/`
- Used `\r?\n` to support both newline conventions (`\n` and `\r\n`)
- Verified regex works across both Windows and Unix-style inputs

## Testing

Manually tested the updated regex on windows and linux with both `\n` and `\r\n` line endings.
