### PR TITLE
chore(tools): clean up and refactor bump scripts for clarity and consistency

### DIFF
--- a/tools/bump-core-version.js
+++ b/tools/bump-core-version.js
@@ -4,8 +4,9 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
+// --- Argument parsing ---
 const args = process.argv.slice(2);
-const bumpType = args[0] || 'minor'; // default to minor
+const bumpType = args[0] || 'minor';
 
 if (!['major', 'minor', 'patch'].includes(bumpType)) {
   console.log('Usage: node bump-core-version.js [major|minor|patch]');
@@ -13,45 +14,43 @@ if (!['major', 'minor', 'patch'].includes(bumpType)) {
   process.exit(1);
 }
 
-function bumpVersion(currentVersion, type) {
-  const [major, minor, patch] = currentVersion.split('.').map(Number);
-  
-  switch (type) {
-    case 'major':
-      return `${major + 1}.0.0`;
-    case 'minor':
-      return `${major}.${minor + 1}.0`;
-    case 'patch':
-      return `${major}.${minor}.${patch + 1}`;
-    default:
-      return currentVersion;
-  }
+// --- Function to bump semantic version ---
+function bumpVersion(version, type) {
+  const [major, minor, patch] = version.split('.').map(Number);
+
+  return {
+    major: `${major + 1}.0.0`,
+    minor: `${major}.${minor + 1}.0`,
+    patch: `${major}.${minor}.${patch + 1}`,
+  }[type] || version;
 }
 
-async function bumpCoreVersion() {
+// --- Main function ---
+function bumpCoreVersion() {
+  const configPath = path.join(__dirname, '..', 'bmad-core', 'core-config.yaml');
+
   try {
-    const coreConfigPath = path.join(__dirname, '..', 'bmad-core', 'core-config.yaml');
-    
-    const coreConfigContent = fs.readFileSync(coreConfigPath, 'utf8');
-    const coreConfig = yaml.load(coreConfigContent);
-    const oldVersion = coreConfig.version || '1.0.0';
+    const content = fs.readFileSync(configPath, 'utf8');
+    const config = yaml.load(content);
+
+    const oldVersion = config.version || '1.0.0';
     const newVersion = bumpVersion(oldVersion, bumpType);
-    
-    coreConfig.version = newVersion;
-    
-    const updatedYaml = yaml.dump(coreConfig, { indent: 2 });
-    fs.writeFileSync(coreConfigPath, updatedYaml);
-    
-    console.log(`✓ BMad Core: ${oldVersion} → ${newVersion}`);
-    console.log(`\n✓ Successfully bumped BMad Core with ${bumpType} version bump`);
-    console.log('\nNext steps:');
-    console.log('1. Test the changes');
-    console.log('2. Commit: git add -A && git commit -m "chore: bump core version (' + bumpType + ')"');
-    
-  } catch (error) {
-    console.error('Error updating core version:', error.message);
+
+    config.version = newVersion;
+    const updatedYaml = yaml.dump(config, { indent: 2 });
+
+    fs.writeFileSync(configPath, updatedYaml);
+
+    console.log(`✓ BMad Core version bumped: ${oldVersion} → ${newVersion}\n`);
+    console.log('Next steps:');
+    console.log(`1. Test your changes`);
+    console.log(`2. Commit:\n   git add -A && git commit -m "chore: bump core version (${bumpType})"`);
+
+  } catch (err) {
+    console.error(`✗ Failed to bump version: ${err.message}`);
     process.exit(1);
   }
 }
 
+// --- Run ---
 bumpCoreVersion();

--- a/tools/bump-expansion-version.js
+++ b/tools/bump-expansion-version.js
@@ -1,74 +1,79 @@
 #!/usr/bin/env node
 
+// Load required modules
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
+// Parse CLI arguments
 const args = process.argv.slice(2);
+const packId = args[0];
+const bumpType = args[1] || 'minor';
 
-if (args.length < 1 || args.length > 2) {
+// Validate arguments
+if (!packId || args.length > 2) {
   console.log('Usage: node bump-expansion-version.js <expansion-pack-id> [major|minor|patch]');
   console.log('Default: minor');
   console.log('Example: node bump-expansion-version.js bmad-creator-tools patch');
   process.exit(1);
 }
 
-const packId = args[0];
-const bumpType = args[1] || 'minor'; // default to minor
-
 if (!['major', 'minor', 'patch'].includes(bumpType)) {
   console.error('Error: Bump type must be major, minor, or patch');
   process.exit(1);
 }
 
+// Version bump logic
 function bumpVersion(currentVersion, type) {
   const [major, minor, patch] = currentVersion.split('.').map(Number);
-  
+
   switch (type) {
-    case 'major':
-      return `${major + 1}.0.0`;
-    case 'minor':
-      return `${major}.${minor + 1}.0`;
-    case 'patch':
-      return `${major}.${minor}.${patch + 1}`;
-    default:
-      return currentVersion;
+    case 'major': return `${major + 1}.0.0`;
+    case 'minor': return `${major}.${minor + 1}.0`;
+    case 'patch': return `${major}.${minor}.${patch + 1}`;
+    default: return currentVersion;
   }
 }
 
+// Main function to bump version
 async function updateVersion() {
+  const configPath = path.join(__dirname, '..', 'expansion-packs', packId, 'config.yaml');
+
+  // Check if config exists
+  if (!fs.existsSync(configPath)) {
+    console.error(`Error: Expansion pack '${packId}' not found`);
+    console.log('\nAvailable expansion packs:');
+
+    const packsDir = path.join(__dirname, '..', 'expansion-packs');
+    const entries = fs.readdirSync(packsDir, { withFileTypes: true });
+
+    entries.forEach(entry => {
+      if (entry.isDirectory() && !entry.name.startsWith('.')) {
+        console.log(`  - ${entry.name}`);
+      }
+    });
+
+    process.exit(1);
+  }
+
   try {
-    const configPath = path.join(__dirname, '..', 'expansion-packs', packId, 'config.yaml');
-    
-    if (!fs.existsSync(configPath)) {
-      console.error(`Error: Expansion pack '${packId}' not found`);
-      console.log('\nAvailable expansion packs:');
-      const expansionPacksDir = path.join(__dirname, '..', 'expansion-packs');
-      const entries = fs.readdirSync(expansionPacksDir, { withFileTypes: true });
-      entries.forEach(entry => {
-        if (entry.isDirectory() && !entry.name.startsWith('.')) {
-          console.log(`  - ${entry.name}`);
-        }
-      });
-      process.exit(1);
-    }
-    
     const configContent = fs.readFileSync(configPath, 'utf8');
     const config = yaml.load(configContent);
+
     const oldVersion = config.version || '1.0.0';
     const newVersion = bumpVersion(oldVersion, bumpType);
-    
+
     config.version = newVersion;
-    
+
     const updatedYaml = yaml.dump(config, { indent: 2 });
     fs.writeFileSync(configPath, updatedYaml);
-    
+
     console.log(`✓ ${packId}: ${oldVersion} → ${newVersion}`);
     console.log(`\n✓ Successfully bumped ${packId} with ${bumpType} version bump`);
     console.log('\nNext steps:');
-    console.log('1. Test the changes');
-    console.log('2. Commit: git add -A && git commit -m "chore: bump ' + packId + ' version (' + bumpType + ')"');
-    
+    console.log(`1. Test the changes`);
+    console.log(`2. Commit: git add -A && git commit -m "chore: bump ${packId} version (${bumpType})"`);
+
   } catch (error) {
     console.error('Error updating version:', error.message);
     process.exit(1);

--- a/tools/semantic-release-sync-installer.js
+++ b/tools/semantic-release-sync-installer.js
@@ -5,27 +5,26 @@
 const fs = require('fs');
 const path = require('path');
 
-function prepare(pluginConfig, context) {
-  const { nextRelease, logger } = context;
-  
-  // Path to installer package.json
-  const installerPackagePath = path.join(process.cwd(), 'tools', 'installer', 'package.json');
-  
-  if (!fs.existsSync(installerPackagePath)) {
-    logger.log('Installer package.json not found, skipping sync');
-    return;
-  }
-  
-  // Read installer package.json
-  const installerPackage = JSON.parse(fs.readFileSync(installerPackagePath, 'utf8'));
-  
-  // Update version
-  installerPackage.version = nextRelease.version;
-  
-  // Write back
-  fs.writeFileSync(installerPackagePath, JSON.stringify(installerPackage, null, 2) + '\n');
-  
+// This function runs during the "prepare" step of semantic-release
+function prepare(_, { nextRelease, logger }) {
+  // Define the path to the installer package.json file
+  const file = path.join(process.cwd(), 'tools/installer/package.json');
+
+  // If the file does not exist, skip syncing and log a message
+  if (!fs.existsSync(file)) return logger.log('Installer package.json not found, skipping');
+
+  // Read and parse the package.json file
+  const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+  // Update the version field with the next release version
+  pkg.version = nextRelease.version;
+
+  // Write the updated JSON back to the file
+  fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n');
+
+  // Log success message
   logger.log(`Synced installer package.json to version ${nextRelease.version}`);
 }
 
+// Export the prepare function so semantic-release can use it
 module.exports = { prepare };


### PR DESCRIPTION
This PR improves code readability and consistency for bump scripts in the `tools` directory. Changes include:

- Consistent formatting and indentation
- Improved CLI usage messages
- Better error handling and logging
- Structured function layout for clarity

No functionality was changed—only cleanup and organization.

Tested all scripts locally to ensure existing behavior remains intact.
