### PR TITLE
fix: broken link ("See available AI agents") in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This two-phase approach eliminates both **planning inconsistency** and **context
 
 - **[Install and Build software with Full Stack Agile AI Team](#quick-start)** → Quick Start Instruction
 - **[Learn how to use BMad](bmad-core/user-guide.md)** → Complete user guide and walkthrough
-- **[See available AI agents](#available-agents)** → Specialized roles for your team
+- **[See available AI agents](/bmad-core/agents))** → Specialized roles for your team
 - **[Explore non-technical uses](#-beyond-software-development---expansion-packs)** → Creative writing, business, wellness, education
 - **[Create my own AI agents](#creating-your-own-expansion-pack)** → Build agents for your domain
 - **[Browse ready-made expansion packs](expansion-packs/)** → Game dev, DevOps, infrastructure and get inspired with ideas and examples


### PR DESCRIPTION
Before: 
when clicked on the link it was not redirecting to correct folder.

After:
Now it redirects to correct directory of available agents