### PR TITLE
feat: add KiloCode IDE integration to BMAD installer

### DIFF
--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -41,7 +41,7 @@ program
   .option('-f, --full', 'Install complete BMad Method')
   .option('-x, --expansion-only', 'Install only expansion packs (no bmad-core)')
   .option('-d, --directory <path>', 'Installation directory')
-  .option('-i, --ide <ide...>', 'Configure for specific IDE(s) - can specify multiple (cursor, claude-code, windsurf, trae, roo, cline, gemini, github-copilot, other)')
+  .option('-i, --ide <ide...>', 'Configure for specific IDE(s) - can specify multiple (cursor, claude-code, windsurf, trae, roo, kilo, cline, gemini, github-copilot, other)')
   .option('-e, --expansion-packs <packs...>', 'Install specific expansion packs (can specify multiple)')
   .action(async (options) => {
     try {
@@ -311,6 +311,7 @@ async function promptInstallation() {
           { name: 'Windsurf', value: 'windsurf' },
           { name: 'Trae', value: 'trae' }, // { name: 'Trae', value: 'trae'}
           { name: 'Roo Code', value: 'roo' },
+          { name: 'Kilo Code', value: 'kilo' },
           { name: 'Cline', value: 'cline' },
           { name: 'Gemini CLI', value: 'gemini' },
           { name: 'Github Copilot', value: 'github-copilot' }

--- a/tools/installer/config/install.config.yaml
+++ b/tools/installer/config/install.config.yaml
@@ -90,3 +90,12 @@ ide-configurations:
       # 4. Requires VS Code 1.101+ with `chat.agent.enabled: true` in settings
       # 5. Agent files are stored in .github/chatmodes/
       # 6. Use `*help` to see available commands and agents
+  kilo:
+    name: Kilo Code
+    format: custom-modes
+    file: .kilocodemodes
+    instructions: |
+      # To use BMAD agents in Kilo Code:
+      # 1. Open the mode selector in VSCode
+      # 2. Select a bmad-{agent} mode (e.g. "bmad-dev")
+      # 3. The AI adopts that agent's persona and capabilities


### PR DESCRIPTION
### What

Added KiloCode IDE integration to the BMad Method, enabling users to activate BMad agents via custom Kilomode rules directly within the KiloCode AI assistant panel.

### Why

KiloCode is a new VSCode-compatible AI IDE built on Roo principles, gaining popularity for its speed and local LLM support. This integration extends BMad’s IDE compatibility to KiloCode users, allowing seamless agent activation and mode switching using Roo-style .kilomodes configuration.

### How

- 	Added `kilocodemodes` entry to `install.config.yaml` for KiloCode setup
-	Implemented `setupKilocode()` in `ide-setup.js`, modeled after `setupRoo()`
-	Added mode descriptions to both KiloCode and Roo in `ide-setup.js`
-	Updated `ide-agent-config.yaml` to include Kilocode-specific agent permissions
-	Enabled Roo-style AI mode adoption (bmad-dev, bmad-pm, etc.) in KiloCode
-	Ensured compatibility with Kilocode’s `.kilocodemodes` format and mode selector UX

### Testing
-	Verified creation of `.kilocodemodes` file with correct instructions and modes
-	Tested agent mode recognition in KiloCode IDE via mode selector
-	Confirmed file-level access restrictions per agent type (e.g., dev, pm, qa)
-	Validated `ide-setup.js` handles KiloCode detection without affecting other IDEs
-	Manually tested in KiloCode with Roo and local LLM backends enabled

### Kilo Code IDE Integration On BMad
<img width="829" height="933" alt="kilocode installation on bmad" src="https://github.com/user-attachments/assets/30baec04-e91d-4bb8-87b7-b98bb9f7319a" />

### Kilo Code 🎭 BMad Usage On VsCode
<img width="675" height="884" alt="bmad kilocode usage on vscode" src="https://github.com/user-attachments/assets/6ae6824c-9fe5-4840-85cd-0b8c467fe878" />

