### PR TITLE
feat: add qwen-code ide support to bmad installer.

### DIFF
--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -41,7 +41,7 @@ program
   .option('-f, --full', 'Install complete BMad Method')
   .option('-x, --expansion-only', 'Install only expansion packs (no bmad-core)')
   .option('-d, --directory <path>', 'Installation directory')
-  .option('-i, --ide <ide...>', 'Configure for specific IDE(s) - can specify multiple (cursor, claude-code, windsurf, trae, roo, kilo, cline, gemini, github-copilot, other)')
+  .option('-i, --ide <ide...>', 'Configure for specific IDE(s) - can specify multiple (cursor, claude-code, windsurf, trae, roo, kilo, cline, gemini, qwen-code, github-copilot, other)')
   .option('-e, --expansion-packs <packs...>', 'Install specific expansion packs (can specify multiple)')
   .action(async (options) => {
     try {
@@ -314,6 +314,7 @@ async function promptInstallation() {
           { name: 'Kilo Code', value: 'kilo' },
           { name: 'Cline', value: 'cline' },
           { name: 'Gemini CLI', value: 'gemini' },
+          { name: 'Qwen Code', value: 'qwen-code' },
           { name: 'Github Copilot', value: 'github-copilot' }
         ]
       }

--- a/tools/installer/config/install.config.yaml
+++ b/tools/installer/config/install.config.yaml
@@ -99,3 +99,15 @@ ide-configurations:
       # 1. Open the mode selector in VSCode
       # 2. Select a bmad-{agent} mode (e.g. "bmad-dev")
       # 3. The AI adopts that agent's persona and capabilities
+
+  qwen-code:
+    name: Qwen Code
+    rule-dir: .qwen/bmad-method/
+    format: single-file
+    command-suffix: .md
+    instructions: |
+      # To use BMad agents with Qwen Code:
+      # 1. The installer creates a .qwen/bmad-method/ directory in your project.
+      # 2. It concatenates all agent files into a single QWEN.md file.
+      # 3. Simply mention the agent in your prompt (e.g., "As *dev, ...").
+      # 4. The Qwen Code CLI will automatically have the context for that agent.


### PR DESCRIPTION
  - Add qwen-code option to CLI IDE selection menu
  - Implement Qwen-Code IDE setup\
  - Support agent activation via *agent-name syntax in qwen-code