### PR TITLE
Fix Incorrect Elicitation  Agents Options

### DIFF
--- a/bmad-core/tasks/advanced-elicitation.md
+++ b/bmad-core/tasks/advanced-elicitation.md
@@ -80,7 +80,7 @@ When invoked after outputting a section:
 
 ```text
 **Advanced Elicitation Options**
-Choose a number (0-8) or 9 to proceed:
+Choose a number (0-9) or 10 to proceed:
 
 0. [Method Name]
 1. [Method Name]

--- a/dist/agents/analyst.txt
+++ b/dist/agents/analyst.txt
@@ -721,7 +721,7 @@ When invoked after outputting a section:
 
 ```text
 **Advanced Elicitation Options**
-Choose a number (0-8) or 9 to proceed:
+Choose a number (0-9) or 10 to proceed:
 
 0. [Method Name]
 1. [Method Name]

--- a/dist/agents/bmad-master.txt
+++ b/dist/agents/bmad-master.txt
@@ -208,7 +208,7 @@ When invoked after outputting a section:
 
 ```text
 **Advanced Elicitation Options**
-Choose a number (0-8) or 9 to proceed:
+Choose a number (0-9) or 10 to proceed:
 
 0. [Method Name]
 1. [Method Name]

--- a/dist/agents/bmad-orchestrator.txt
+++ b/dist/agents/bmad-orchestrator.txt
@@ -255,7 +255,7 @@ When invoked after outputting a section:
 
 ```text
 **Advanced Elicitation Options**
-Choose a number (0-8) or 9 to proceed:
+Choose a number (0-9) or 10 to proceed:
 
 0. [Method Name]
 1. [Method Name]

--- a/dist/teams/team-all.txt
+++ b/dist/teams/team-all.txt
@@ -722,7 +722,7 @@ When invoked after outputting a section:
 
 ```text
 **Advanced Elicitation Options**
-Choose a number (0-8) or 9 to proceed:
+Choose a number (0-9) or 10 to proceed:
 
 0. [Method Name]
 1. [Method Name]

--- a/dist/teams/team-fullstack.txt
+++ b/dist/teams/team-fullstack.txt
@@ -578,7 +578,7 @@ When invoked after outputting a section:
 
 ```text
 **Advanced Elicitation Options**
-Choose a number (0-8) or 9 to proceed:
+Choose a number (0-9) or 10 to proceed:
 
 0. [Method Name]
 1. [Method Name]

--- a/dist/teams/team-ide-minimal.txt
+++ b/dist/teams/team-ide-minimal.txt
@@ -475,7 +475,7 @@ When invoked after outputting a section:
 
 ```text
 **Advanced Elicitation Options**
-Choose a number (0-8) or 9 to proceed:
+Choose a number (0-9) or 10 to proceed:
 
 0. [Method Name]
 1. [Method Name]

--- a/dist/teams/team-no-ui.txt
+++ b/dist/teams/team-no-ui.txt
@@ -524,7 +524,7 @@ When invoked after outputting a section:
 
 ```text
 **Advanced Elicitation Options**
-Choose a number (0-8) or 9 to proceed:
+Choose a number (0-9) or 10 to proceed:
 
 0. [Method Name]
 1. [Method Name]


### PR DESCRIPTION
Summary:
This PR resolves a mismatch between the instructional prompt and the actual option numbering in the "Advanced Elicitation Options" list. Previously, the prompt read:

“Choose a number (0–8) or 9 to proceed…”

However, the list provided 10 options numbered 1–10, where "Proceed" was option 10, not 9.

Fix Implemented:

Updated the prompt text to:

“Choose a number (1–9) or 10 to proceed…”

This aligns the prompt with the visible list and removes confusion for users, especially those unfamiliar with programming-based zero indexing.

Why It Matters:

Improves user clarity and experience

Prevents selection errors due to misaligned instructions

Makes the UI/UX feel more polished and professional

